### PR TITLE
typo fix config.md

### DIFF
--- a/config.md
+++ b/config.md
@@ -5,7 +5,7 @@
 | Variable                                                | Default     | Description                                                                                        |
 | ------------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------- |
 | URL                                                     | -           | used for setting the address manager address                                                       |
-| DATA_TRANSPORT_LAYER__ADDRESS_MANAGER                   | -           | Address of the AddressManager contract on L1., recommend using `URL` settting.                     |
+| DATA_TRANSPORT_LAYER__ADDRESS_MANAGER                   | -           | Address of the AddressManager contract on L1., recommend using `URL` setting.                     |
 | DATA_TRANSPORT_LAYER__DB_PATH                           | /data/db    | Path to the database for this service                                                              |
 | DATA_TRANSPORT_LAYER__POLLING_INTERVAL                  | 5000        | Period of time between execution loops.                                                            |
 | DATA_TRANSPORT_LAYER__DANGEROUSLY_CATCH_ALL_ERRORS      | false       | If true, will catch all errors without throwing.                                                   |


### PR DESCRIPTION
## Description
This pull request corrects a typo in `config.md`:

- Fixed a repeated word in the description of the `DATA_TRANSPORT_LAYER__ADDRESS_MANAGER` variable, changing "settting" to "setting".

## Motivation and Context
Ensuring accuracy in documentation is important for clarity and professionalism. These changes enhance the readability of the configuration guide.

## How Has This Been Tested?
No functional changes were made, only documentation updates. The file was reviewed to confirm the corrections.

## Types of Changes
- Documentation (typo fix)

## Checklist:
- [x] My changes do not introduce any breaking changes.
- [x] I have reviewed the document after my edits for correctness.
- [x] I have read the contributing guidelines.
- [x] My pull request targets the correct branch.

## Additional Notes
I look forward to contributing more to this project. Please let me know if there are additional areas I can assist with.
