### PR TITLE
fix typo Update config.md

### DIFF
--- a/config.md
+++ b/config.md
@@ -31,7 +31,7 @@
 | Variable                   | Default               | Description                                                                                                      |
 | -------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | BLOCK_SIGNER_KEY           |                       | only used internally to sign blocks,no need to keep this secret                                                  |
-| BLOCK_SIGNER_ADDRESS       |                       | block signer adddress                                                                                            |
+| BLOCK_SIGNER_ADDRESS       |                       | block signer address                                                                                            |
 | ROLLUP_CLIENT_HTTP         | http://localhost:7878 | HTTP endpoint for the rollup client                                                                              |
 | ROLLUP_POLL_INTERVAL_FLAG  | 10s                   | Interval for polling with the rollup http client                                                                 |
 | ROLLUP_TIMESTAMP_REFRESH   | 3min                  | Interval for refreshing the timestamp                                                                            |


### PR DESCRIPTION
# Pull Request Title: Fix Typo in config.md

## Description
This pull request fixes a typo in the `config.md` file where the word "adddress" is incorrectly used. It has been corrected to "address."

## Related Issue
<!-- If applicable, link to the related issue (e.g., #123). -->

## Changes
- Corrected the typo "adddress" to "address" in the `config.md` file.

## Typo Fixes
- **Typo**: "adddress" has been corrected to "address" in the `config.md` file.

## Testing
No testing is required, as this is a simple typo fix in documentation.

## Additional Notes
This fix helps improve clarity in the documentation. No functional changes to the codebase.
